### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,4 +1,6 @@
 name: Test Build
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/KevinSilvester/mern-movie/security/code-scanning/1](https://github.com/KevinSilvester/mern-movie/security/code-scanning/1)

The best way to fix the problem is to add a `permissions:` block at the top level of the workflow file (.github/workflows/test_build.yml), directly under the workflow `name:` line and before the `on:` block. This permissions block should specify the minimal required permissions for the workflow, which in this case is likely `contents: read`, as none of the steps need to write to the repo or interact with PRs/issues. No other changes are needed. This fixes the permission inheritance problem without impacting the workflow's functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
